### PR TITLE
Add JDK 11 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,22 +106,27 @@
 
 	<dependencies>
 		<dependency>
-		    <groupId>com.google.code.gson</groupId>
-		    <artifactId>gson</artifactId>
-		    <version>2.10.1</version>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.10.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
 			<version>5.13.0</version>
 		</dependency>
-<!--
 		<dependency>
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<version>1.30</version>
+			<groupId>javax.activation</groupId>
+			<artifactId>javax.activation-api</artifactId>
+			<version>1.2.0</version>
 		</dependency>
-!-->
+		<!--
+                <dependency>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                    <version>1.30</version>
+                </dependency>
+        !-->
 	</dependencies>
 
 	<distributionManagement>


### PR DESCRIPTION
Include javax.activation-api 1.2.0 in pom.xml so that javax.activation.UnsupportedDataTypeException is available as import for JDK > 8